### PR TITLE
Update dependencies and trait implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,24 @@ name = "lis3dh"
 description = "An embedded-hal driver for the LIS3DH accelerometer that implements the generic accelerometer trait"
 version = "0.1.0"
 license = "Apache-2.0 OR MIT"
-authors = ["Benjamin Bergman <ben@benbergman.ca>", "Paul Sajna <sajattack@gmail.com>"]
-edition = "2018"
-keywords = ["embedded-hal-driver", "accelerometer"]
+authors = [
+    "Benjamin Bergman <ben@benbergman.ca>",
+    "Paul Sajna <sajattack@gmail.com>",
+    "Jesse Braham <jesse@beta7.io>",
+]
+keywords = [
+    "embedded-hal-driver",
+    "accelerometer",
+]
 repository = "https://github.com/BenBergman/lis3dh-rs"
+edition = "2018"
 
 [dependencies]
+accelerometer = "~0.12"
 embedded-hal = "~0.2"
-accelerometer = { version = "~0.6", features = ["orientation"] }
 
 [dev-dependencies]
-circuit_playground_express = { version = "~0.4.0", features = ["use_semihosting"] }
-panic-halt = "~0.2"
+circuit_playground_express = { version = "~0.7", features = ["use_semihosting"] }
 cortex-m-rt = "~0.6"
 cortex-m-semihosting = "~0.3"
+panic-halt = "~0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2018"
 [dependencies]
 accelerometer = "~0.12"
 embedded-hal = "~0.2"
+num_enum = { version = "~0.5", default-features = false }
 
 [dev-dependencies]
 circuit_playground_express = { version = "~0.7", features = ["use_semihosting"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,25 @@
+//! Platform-agnostic LIS3DH accelerometer driver which uses I²C via
+//! [embedded-hal]. This driver implements the [`Accelerometer`][acc-trait]
+//! and [`RawAccelerometer`][raw-trait] traits from the `accelerometer` crate.
+//!
+//! [embedded-hal]: https://docs.rs/embedded-hal
+//! [acc-trait]: https://docs.rs/accelerometer/latest/accelerometer/trait.Accelerometer.html
+//! [raw-trait]: https://docs.rs/accelerometer/latest/accelerometer/trait.RawAccelerometer.html
+//!
+
 #![no_std]
-#![allow(non_camel_case_types)]
+
+use core::convert::TryInto;
+use core::fmt::Debug;
+
+use accelerometer;
+use accelerometer::error::Error as AccelerometerError;
+use accelerometer::vector::{F32x3, I16x3};
+use accelerometer::{Accelerometer, RawAccelerometer, Tracker};
+use embedded_hal::blocking::i2c::{Write, WriteRead};
 
 mod register;
-
-use core::fmt::Debug;
-use core::convert::TryInto;
-use embedded_hal::blocking::i2c::{WriteRead, Write};
-
-pub use register::Register;
-pub use accelerometer;
-use accelerometer::{I16x3, Accelerometer, Tracker};
+pub use register::*;
 
 #[derive(Debug)]
 pub enum Error<E> {
@@ -19,91 +29,35 @@ pub enum Error<E> {
     WrongAddress,
     WriteToReadOnly,
     InvalidDataRate,
+    InvalidMode,
     InvalidRange,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(u8)]
-pub enum Range {
-    G16 = 0b11,  //  +/- 16g
-    G8  = 0b10,  //  +/-  8g
-    G4  = 0b01,  //  +/-  4g
-    G2  = 0b00,  //  +/-  2g
-    Invalid = 0xff,
-}
-
-impl Range {
-    pub fn bits(self) -> u8 {
-        self as u8
-    }
-
-    fn from(value: u8) -> Range {
-        match value {
-            0b11 => Range::G16,
-            0b10 => Range::G8,
-            0b01 => Range::G4,
-            0b00 => Range::G2,
-            _ => Range::Invalid
-        }
-    }
-}
-
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-#[repr(u8)]
-pub enum DataRate {
-    Hz_1344_LP5k   = 0b1001, // 1344Hz in normal mode, 5KHz in low power mode
-    Hz_400         = 0b0111,
-    Hz_200         = 0b0110,
-    Hz_100         = 0b0101,
-    Hz_50          = 0b0100,
-    Hz_25          = 0b0011,
-    Hz_10          = 0b0010,
-    Hz_1           = 0b0001,
-    PowerDown      = 0b0000,
-    LowPower_1K6HZ = 0b1000,
-    Invalid        = 0xff,
-}
-
-impl DataRate {
-    pub fn bits(self) -> u8 {
-        self as u8
-    }
-
-    fn from(value: u8) -> DataRate {
-        match value {
-            0b1001 => DataRate::Hz_1344_LP5k,
-            0b0111 => DataRate::Hz_400,
-            0b0110 => DataRate::Hz_200,
-            0b0101 => DataRate::Hz_100,
-            0b0100 => DataRate::Hz_50,
-            0b0011 => DataRate::Hz_25,
-            0b0010 => DataRate::Hz_10,
-            0b0001 => DataRate::Hz_1,
-            0b0000 => DataRate::PowerDown,
-            0b1000 => DataRate::LowPower_1K6HZ,
-            _ => DataRate::Invalid,
-        }
-    }
-}
-
+/// `LIS3DH` driver
 pub struct Lis3dh<I2C> {
+    /// Underlying I²C device
     i2c: I2C,
+
+    /// Current I²C slave address
     address: u8,
 }
 
 impl<I2C, E> Lis3dh<I2C>
 where
-    I2C: WriteRead<Error = E> + Write<Error = E>
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    E: Debug,
 {
-    pub fn new(i2c: I2C, address: u8) -> Result<Self, Error<E>> {
-        let mut lis3dh = Lis3dh { i2c, address };
+    /// Create a new LIS3DH driver from the given I2C peripheral
+    pub fn new(i2c: I2C, address: SlaveAddr) -> Result<Self, Error<E>> {
+        let mut lis3dh = Lis3dh {
+            i2c,
+            address: address.addr(),
+        };
 
-        let buf = lis3dh.read_register(Register::WHOAMI)?;
-
-        if buf != 0x33 {
-            return Err(Error::WrongAddress)
+        if lis3dh.get_device_id()? != DEVICE_ID {
+            return Err(Error::WrongAddress);
         }
+
         // Enable all axes, normal mode.
         lis3dh.write_register(Register::CTRL1, 0x07)?;
         // Set 400Hz data rate.
@@ -114,84 +68,228 @@ where
         lis3dh.write_register(Register::TEMP_CFG, 0x80)?;
         // Latch interrupt for INT1
         lis3dh.write_register(Register::CTRL5, 0x08)?;
+
         Ok(lis3dh)
     }
 
+    /// `WHO_AM_I` register
+    pub fn get_device_id(&mut self) -> Result<u8, Error<E>> {
+        self.read_register(Register::WHOAMI)
+    }
+
+    /// Operating mode selection.
+    /// `CTRL_REG1`: `LPen` bit, `CTRL_REG4`: `HR` bit
+    pub fn set_mode(&mut self, mode: Mode) -> Result<(), Error<E>> {
+        match mode {
+            Mode::LowPower => {
+                self.register_set_bits(Register::CTRL1, 0x8)?;
+                self.register_reset_bits(Register::CTRL4, 0x8)?;
+            }
+            Mode::Normal => {
+                self.register_reset_bits(Register::CTRL1, 0x8)?;
+                self.register_reset_bits(Register::CTRL4, 0x8)?;
+            }
+            Mode::HighResolution => {
+                self.register_reset_bits(Register::CTRL1, 0x8)?;
+                self.register_set_bits(Register::CTRL4, 0x8)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read the current operating mode
+    pub fn get_mode(&mut self) -> Result<Mode, Error<E>> {
+        let ctrl1 = self.read_register(Register::CTRL1)?;
+        let ctrl4 = self.read_register(Register::CTRL4)?;
+
+        let lp = (ctrl1 >> 3) & 0x1 != 0;
+        let hr = (ctrl4 >> 3) & 0x1 != 0;
+
+        let mode = match (lp, hr) {
+            (true, false) => Mode::LowPower,
+            (false, false) => Mode::Normal,
+            (false, true) => Mode::HighResolution,
+            _ => return Err(Error::InvalidMode)
+        };
+
+        Ok(mode)
+    }
+
+    /// Data rate selection
     pub fn set_datarate(&mut self, datarate: DataRate) -> Result<(), Error<E>> {
         if datarate == DataRate::Invalid {
             return Err(Error::InvalidDataRate);
         }
-        let mut ctrl1 = self.read_register(Register::CTRL1)?;
-        ctrl1 &= !0xf0;
+
+        self.modify_register(Register::CTRL1, |mut ctrl1| {
+            // Mask off lowest 4 bits
+            ctrl1 &= 0xF;
+            // Write in new data rate to highest 4 bits
         ctrl1 |= datarate.bits() << 4;
-        self.write_register(Register::CTRL1, ctrl1)
+
+            ctrl1
+        })
     }
 
+    /// Read the current data selection rate
     pub fn get_datarate(&mut self) -> Result<DataRate, Error<E>> {
         let ctrl1 = self.read_register(Register::CTRL1)?;
+
         Ok(DataRate::from((ctrl1 >> 4) & 0x0F))
     }
 
+    /// Range selection
     pub fn set_range(&mut self, range: Range) -> Result<(), Error<E>> {
-        if range  == Range::Invalid {
+        if range == Range::Invalid {
             return Err(Error::InvalidRange);
         }
-        let mut ctrl4 = self.read_register(Register::CTRL4)?;
+
+        self.modify_register(Register::CTRL4, |mut ctrl4| {
+            // Mask off lowest 4 bits
         ctrl4 &= !0x30;
+            // Write in new range to highest 4 bits
         ctrl4 |= range.bits() << 4;
-        self.write_register(Register::CTRL4, ctrl4)
+
+            ctrl4
+        })
     }
 
+    /// Read the current range
     pub fn get_range(&mut self) -> Result<Range, Error<E>> {
         let ctrl4 = self.read_register(Register::CTRL4)?;
+
         Ok(Range::from((ctrl4 >> 4) & 0x03))
     }
 
-    pub fn read_register(&mut self, register: Register) -> Result<u8, Error<E>> {
-        let mut data = [0];
-        self.i2c
-            .write_read(self.address, &[register.addr()], &mut data)
-            .map_err(Error::I2C)
-            .and(Ok(data[0]))
+    /// Use this accelerometer as an orientation tracker
+    pub fn try_into_tracker(&mut self) -> Result<Tracker, Error<E>> {
+        self.set_range(Range::G8)?;
+        Ok(Tracker::new(3700.0))
     }
 
-    fn read_accel_bytes(&mut self) -> Result<[u8;6], Error<E>> {
-        let mut data = [0u8;6];
+    /// Modify a register's value
+    fn modify_register<F>(&mut self, register: Register, f: F) -> Result<(), Error<E>>
+    where
+        F: FnOnce(u8) -> u8,
+    {
+        let value = self.read_register(register)?;
+        self.write_register(register, f(value))?;
+
+        Ok(())
+    }
+
+    fn register_reset_bits(&mut self, reg: Register, bits: u8) -> Result<(), Error<E>> {
+        self.modify_register(reg, |v| v & !bits)
+    }
+
+    fn register_set_bits(&mut self, reg: Register, bits: u8) -> Result<(), Error<E>> {
+        self.modify_register(reg, |v| v | bits)
+    }
+
+    /// Read from the registers for each of the 3 axes
+    fn read_accel_bytes(&mut self) -> Result<[u8; 6], Error<E>> {
+        let mut data = [0u8; 6];
+
         self.i2c
             .write_read(self.address, &[Register::OUT_X_L.addr() | 0x80], &mut data)
             .map_err(Error::I2C)
             .and(Ok(data))
     }
 
-    pub fn write_register(&mut self, register: Register, value: u8) -> Result<(), Error<E>> {
+    /// Write to the given register
+    fn write_register(&mut self, register: Register, value: u8) -> Result<(), Error<E>> {
         if register.read_only() {
             return Err(Error::WriteToReadOnly);
         }
-        self.i2c.write(self.address, &[register.addr(), value]).map_err(Error::I2C)
+
+        self.i2c
+            .write(self.address, &[register.addr(), value])
+            .map_err(Error::I2C)
     }
 
-    pub fn try_into_tracker(mut self) -> Result<Tracker<Self, I16x3>, Error<E>> 
-    where 
-        E: Debug
-    {
-        self.set_range(Range::G8)?;
-        Ok(Tracker::new(self, 3700))
+    /// Read from the given register
+    fn read_register(&mut self, register: Register) -> Result<u8, Error<E>> {
+        let mut data = [0];
+
+        self.i2c
+            .write_read(self.address, &[register.addr()], &mut data)
+            .map_err(Error::I2C)
+            .and(Ok(data[0]))
     }
 }
 
-impl<I2C, E> Accelerometer<I16x3> for Lis3dh<I2C>
+impl<I2C, E> Accelerometer for Lis3dh<I2C>
+    where 
+    I2C: WriteRead<Error = E> + Write<Error = E>,
+    E: Debug,
+{
+    type Error = Error<E>;
+
+    /// Get normalized ±g reading from the accelerometer
+    fn accel_norm(&mut self) -> Result<F32x3, AccelerometerError<Self::Error>> {
+        let range = self.get_range()?;
+        if range == Range::Invalid {
+            return Err(AccelerometerError::from(Self::Error::InvalidRange));
+        }
+
+        let acc_raw: I16x3 = self.accel_raw()?;
+        let sensitivity = match range {
+            Range::G16 => 0.012,
+            Range::G8 => 0.004,
+            Range::G4 => 0.002,
+            Range::G2 => 0.001,
+            _ => unreachable!(),
+        };
+
+        Ok(F32x3::new(
+            (acc_raw.x >> 4) as f32 * sensitivity,
+            (acc_raw.y >> 4) as f32 * sensitivity,
+            (acc_raw.z >> 4) as f32 * sensitivity,
+        ))
+    }
+
+    /// Get the sample rate of the accelerometer data
+    fn sample_rate(&mut self) -> Result<f32, AccelerometerError<Self::Error>> {
+        let sample_rate = match self.get_datarate()? {
+            DataRate::Hz_1344_LP5k => {
+                if self.get_mode()? == Mode::LowPower {
+                    5376.0
+                } else {
+                    1344.0
+                }
+            }
+            DataRate::Hz_400 => 400.0,
+            DataRate::Hz_200 => 200.0,
+            DataRate::Hz_100 => 100.0,
+            DataRate::Hz_50 => 50.0,
+            DataRate::Hz_25 => 25.0,
+            DataRate::Hz_10 => 10.0,
+            DataRate::Hz_1 => 1.0,
+            DataRate::PowerDown => 0.0,
+            DataRate::LowPower_1K6HZ => 1600.0,
+            DataRate::Invalid => 0.0,
+        };
+
+        Ok(sample_rate)
+    }
+}
+
+impl<I2C, E> RawAccelerometer<I16x3> for Lis3dh<I2C>
 where
     I2C: WriteRead<Error = E> + Write<Error = E>,
     E: Debug,
 {
     type Error = Error<E>;
 
-    /// Get acceleration reading from the accelerometer
-    fn acceleration(&mut self) -> Result<I16x3, Error<E>> {
-       let accel_bytes = self.read_accel_bytes()?;
-       let x = i16::from_le_bytes(accel_bytes[0..2].try_into().unwrap());
-       let y = i16::from_le_bytes(accel_bytes[2..4].try_into().unwrap());
-       let z = i16::from_le_bytes(accel_bytes[4..6].try_into().unwrap());
-       Ok(I16x3::new(x, y, z))
+    /// Get raw acceleration data from the accelerometer.
+    fn accel_raw(&mut self) -> Result<I16x3, AccelerometerError<Self::Error>> {
+        let accel_bytes = self.read_accel_bytes()?;
+
+        let x = i16::from_le_bytes(accel_bytes[0..2].try_into().unwrap());
+        let y = i16::from_le_bytes(accel_bytes[2..4].try_into().unwrap());
+        let z = i16::from_le_bytes(accel_bytes[4..6].try_into().unwrap());
+
+        Ok(I16x3::new(x, y, z))
     }
 }

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,7 +1,11 @@
+use num_enum::TryFromPrimitive;
+
 /// Unique device identifier
 pub const DEVICE_ID: u8 = 0x33;
 
 /// Possible I²C slave addresses
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub enum SlaveAddr {
     /// Default slave address (0x18)
     Default = 0x18,
@@ -99,7 +103,7 @@ impl Register {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum Range {
     /// ±16g
@@ -113,8 +117,6 @@ pub enum Range {
 
     /// ±2g (Default)
     G2 = 0b00,
-
-    Invalid = 0xFF,
 }
 
 impl Range {
@@ -123,20 +125,8 @@ impl Range {
     }
 }
 
-impl From<u8> for Range {
-    fn from(value: u8) -> Range {
-        match value {
-            0b11 => Range::G16,
-            0b10 => Range::G8,
-            0b01 => Range::G4,
-            0b00 => Range::G2,
-            _ => Range::Invalid,
-        }
-    }
-}
-
 #[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum DataRate {
     /// 400Hz (Default)
@@ -168,31 +158,11 @@ pub enum DataRate {
 
     /// # Normal power mode (1344Hz) / Low power mode (5KHz)
     Hz_1344_LP5k = 0b1001,
-
-    Invalid = 0xFF,
 }
 
 impl DataRate {
     pub fn bits(self) -> u8 {
         self as u8
-    }
-}
-
-impl From<u8> for DataRate {
-    fn from(value: u8) -> DataRate {
-        match value {
-            0b1001 => DataRate::Hz_1344_LP5k,
-            0b0111 => DataRate::Hz_400,
-            0b0110 => DataRate::Hz_200,
-            0b0101 => DataRate::Hz_100,
-            0b0100 => DataRate::Hz_50,
-            0b0011 => DataRate::Hz_25,
-            0b0010 => DataRate::Hz_10,
-            0b0001 => DataRate::Hz_1,
-            0b0000 => DataRate::PowerDown,
-            0b1000 => DataRate::LowPower_1K6HZ,
-            _ => DataRate::Invalid,
-        }
     }
 }
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,80 +1,211 @@
-#![allow(non_camel_case_types)]
+/// Unique device identifier
+pub const DEVICE_ID: u8 = 0x33;
 
+/// Possible I²C slave addresses
+pub enum SlaveAddr {
+    /// Default slave address (0x18)
+    Default = 0x18,
+
+    /// Alternate slave address (0x19)
+    Alternate = 0x19,
+}
+
+impl SlaveAddr {
+    pub fn addr(self) -> u8 {
+        return self as u8;
+    }
+}
+
+/// Enumerate all device registers
+#[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Register {
-    STATUS_AUX      = 0x07,
-    OUT_ADC1_L      = 0x08,
-    OUT_ADC1_H      = 0x09,
-    OUT_ADC2_L      = 0x0A,
-    OUT_ADC2_H      = 0x0B,
-    OUT_ADC3_L      = 0x0C,
-    OUT_ADC3_H      = 0x0D,
-    WHOAMI          = 0x0F,
-    CTRL0           = 0x1E,
-    TEMP_CFG        = 0x1F,
-    CTRL1           = 0x20,
-    CTRL2           = 0x21,
-    CTRL3           = 0x22,
-    CTRL4           = 0x23,
-    CTRL5           = 0x24,
-    CTRL6           = 0x25,
-    REFERENCE       = 0x26,
-    STATUS          = 0x27,
-    OUT_X_L         = 0x28,
-    OUT_X_H         = 0x29,
-    OUT_Y_L         = 0x2A,
-    OUT_Y_H         = 0x2B,
-    OUT_Z_L         = 0x2C,
-    OUT_Z_H         = 0x2D,
-    FIFO_CTRL       = 0x2E,
-    FIFO_SRC        = 0x2F,
-    INT1_CFG        = 0x30,
-    INT1_SRC        = 0x31,
-    INT1_THS        = 0x32,
-    INT1_DURATION   = 0x33,
-    INT2_CFG        = 0x34,
-    INT2_SRC        = 0x35,
-    INT2_THS        = 0x36,
-    INT2_DURATION   = 0x37,
-    CLICK_CFG       = 0x38,
-    CLICK_SRC       = 0x39,
-    CLICK_THS       = 0x3A,
-    TIME_LIMIT      = 0x3B,
-    TIME_LATENCY    = 0x3C,
-    TIME_WINDOW     = 0x3D,
-    ACT_THS         = 0x3E,
-    ACT_DUR         = 0x3F,
+    STATUS_AUX = 0x07,
+    OUT_ADC1_L = 0x08,
+    OUT_ADC1_H = 0x09,
+    OUT_ADC2_L = 0x0A,
+    OUT_ADC2_H = 0x0B,
+    OUT_ADC3_L = 0x0C,
+    OUT_ADC3_H = 0x0D,
+    WHOAMI = 0x0F,
+    CTRL0 = 0x1E,
+    TEMP_CFG = 0x1F,
+    CTRL1 = 0x20,
+    CTRL2 = 0x21,
+    CTRL3 = 0x22,
+    CTRL4 = 0x23,
+    CTRL5 = 0x24,
+    CTRL6 = 0x25,
+    REFERENCE = 0x26,
+    STATUS = 0x27,
+    OUT_X_L = 0x28,
+    OUT_X_H = 0x29,
+    OUT_Y_L = 0x2A,
+    OUT_Y_H = 0x2B,
+    OUT_Z_L = 0x2C,
+    OUT_Z_H = 0x2D,
+    FIFO_CTRL = 0x2E,
+    FIFO_SRC = 0x2F,
+    INT1_CFG = 0x30,
+    INT1_SRC = 0x31,
+    INT1_THS = 0x32,
+    INT1_DURATION = 0x33,
+    INT2_CFG = 0x34,
+    INT2_SRC = 0x35,
+    INT2_THS = 0x36,
+    INT2_DURATION = 0x37,
+    CLICK_CFG = 0x38,
+    CLICK_SRC = 0x39,
+    CLICK_THS = 0x3A,
+    TIME_LIMIT = 0x3B,
+    TIME_LATENCY = 0x3C,
+    TIME_WINDOW = 0x3D,
+    ACT_THS = 0x3E,
+    ACT_DUR = 0x3F,
 }
 
 impl Register {
+    /// Get register address
     pub fn addr(self) -> u8 {
         self as u8
     }
 
+    /// Is the register read-only?
     pub fn read_only(self) -> bool {
         match self {
-            Register::STATUS_AUX |
-            Register::OUT_ADC1_L |
-            Register::OUT_ADC1_H |
-            Register::OUT_ADC2_L |
-            Register::OUT_ADC2_H |
-            Register::OUT_ADC3_L |
-            Register::OUT_ADC3_H |
-            Register::WHOAMI |
-            Register::STATUS |
-            Register::OUT_X_L |
-            Register::OUT_X_H |
-            Register::OUT_Y_L |
-            Register::OUT_Y_H |
-            Register::OUT_Z_L |
-            Register::OUT_Z_H |
-            Register::FIFO_SRC |
-            Register::INT1_SRC |
-            Register::INT2_SRC |
-            Register::CLICK_SRC  => true,
+            Register::STATUS_AUX
+            | Register::OUT_ADC1_L
+            | Register::OUT_ADC1_H
+            | Register::OUT_ADC2_L
+            | Register::OUT_ADC2_H
+            | Register::OUT_ADC3_L
+            | Register::OUT_ADC3_H
+            | Register::WHOAMI
+            | Register::STATUS
+            | Register::OUT_X_L
+            | Register::OUT_X_H
+            | Register::OUT_Y_L
+            | Register::OUT_Y_H
+            | Register::OUT_Z_L
+            | Register::OUT_Z_H
+            | Register::FIFO_SRC
+            | Register::INT1_SRC
+            | Register::INT2_SRC
+            | Register::CLICK_SRC => true,
             _ => false,
         }
     }
 }
 
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Range {
+    /// ±16g
+    G16 = 0b11,
+
+    /// ±8g
+    G8 = 0b10,
+
+    /// ±4g
+    G4 = 0b01,
+
+    /// ±2g (Default)
+    G2 = 0b00,
+
+    Invalid = 0xFF,
+}
+
+impl Range {
+    pub fn bits(self) -> u8 {
+        self as u8
+    }
+}
+
+impl From<u8> for Range {
+    fn from(value: u8) -> Range {
+        match value {
+            0b11 => Range::G16,
+            0b10 => Range::G8,
+            0b01 => Range::G4,
+            0b00 => Range::G2,
+            _ => Range::Invalid,
+        }
+    }
+}
+
+#[allow(non_camel_case_types)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum DataRate {
+    /// 400Hz (Default)
+    Hz_400 = 0b0111,
+
+    /// 200Hz
+    Hz_200 = 0b0110,
+
+    /// 100Hz
+    Hz_100 = 0b0101,
+
+    /// 50Hz
+    Hz_50 = 0b0100,
+
+    /// 25Hz
+    Hz_25 = 0b0011,
+
+    /// 10Hz
+    Hz_10 = 0b0010,
+
+    /// 1Hz
+    Hz_1 = 0b0001,
+
+    /// Power down
+    PowerDown = 0b0000,
+
+    /// Low power mode (1.6KHz)
+    LowPower_1K6HZ = 0b1000,
+
+    /// # Normal power mode (1344Hz) / Low power mode (5KHz)
+    Hz_1344_LP5k = 0b1001,
+
+    Invalid = 0xFF,
+}
+
+impl DataRate {
+    pub fn bits(self) -> u8 {
+        self as u8
+    }
+}
+
+impl From<u8> for DataRate {
+    fn from(value: u8) -> DataRate {
+        match value {
+            0b1001 => DataRate::Hz_1344_LP5k,
+            0b0111 => DataRate::Hz_400,
+            0b0110 => DataRate::Hz_200,
+            0b0101 => DataRate::Hz_100,
+            0b0100 => DataRate::Hz_50,
+            0b0011 => DataRate::Hz_25,
+            0b0010 => DataRate::Hz_10,
+            0b0001 => DataRate::Hz_1,
+            0b0000 => DataRate::PowerDown,
+            0b1000 => DataRate::LowPower_1K6HZ,
+            _ => DataRate::Invalid,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+/// Operating mode
+pub enum Mode {
+    /// High-resolution mode (12-bit data output)
+    HighResolution,
+
+    /// Normal mode (10-bit data output)
+    Normal,
+
+    /// Low-power mode (8-bit data output)
+    LowPower,
+}


### PR DESCRIPTION
This PR updates all dependencies to their newest versions, including a change of `accelerometer` from  `0.6` to `0.12`. The `Accelerometer` and `RawAccelerometer` traits were implemented, and a small amount of new functionality was added.

I used the [`num_enum`](https://github.com/illicitonion/num_enum) crate to perform predictable conversions between enums and primitive types, which allowed for the removal of the `Invalid` members from `DataRate` and `Range`.

Note than many of the changes were taken almost directly from the [`lis2dh12`](https://github.com/tkeksa/lis2dh12/) crate, as it is _very_ similar to this one. I have done a fair amount of testing using an Adafruit Trinket M0 along with an LIS3DH on a breakout board. I've confirmed that `read_raw`, `read_norm` and the orientation tracking are working for my setup.

If there are any changes you would like made or if you have any questions please just let me know.