### PR TITLE
Api cleanup and documentation

### DIFF
--- a/examples/cpx.rs
+++ b/examples/cpx.rs
@@ -4,7 +4,7 @@
 use circuit_playground_express as hal;
 extern crate panic_halt;
 
-use accelerometer::RawAccelerometer;
+use accelerometer::{RawAccelerometer, Tracker};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::hprintln;
 use hal::clock::GenericClockController;
@@ -42,7 +42,7 @@ fn main() -> ! {
     lis3dh.set_range(lis3dh::Range::G8).unwrap();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let mut tracker = lis3dh.try_into_tracker().unwrap();
+    let mut tracker = Tracker::new(3700.0);
 
     loop {
         let accel = lis3dh.accel_raw().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,20 +244,6 @@ where
         Ok((value as f32) * 0.25)
     }
 
-    /// Reboot memory content.
-    /// `CTRL_REG5`: `BOOT`
-    pub fn reboot(&mut self, reboot: bool) -> Result<(), Error<E>> {
-        self.register_xset_bits(Register::CTRL5, BOOT, reboot)
-    }
-
-    /// In boot,
-    /// `CTRL_REG5`: `BOOT`
-    pub fn is_in_boot(&mut self) -> Result<bool, Error<E>> {
-        let ctrl5 = self.read_register(Register::CTRL5)?;
-
-        Ok((ctrl5 & BOOT) != 0)
-    }
-
     /// Use this accelerometer as an orientation tracker
     pub fn try_into_tracker(&mut self) -> Result<Tracker, Error<E>> {
         self.set_range(Range::G8)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,9 @@ where
 {
     type Error = Error<E>;
 
-    /// Get normalized ±g reading from the accelerometer
+    /// Get normalized ±g reading from the accelerometer. You should be reading
+    /// based on data ready interrupt or if reading in a tight loop you should
+    /// waiting for `is_data_ready`
     fn accel_norm(&mut self) -> Result<F32x3, AccelerometerError<Self::Error>> {
         let acc_raw: I16x3 = self.accel_raw()?;
         let sensitivity = match self.get_range()? {
@@ -384,7 +386,9 @@ where
 {
     type Error = Error<E>;
 
-    /// Get raw acceleration data from the accelerometer.
+    /// Get raw acceleration data from the accelerometer. You should be reading
+    /// based on data ready interrupt or if reading in a tight loop you should
+    /// waiting for `is_data_ready`
     fn accel_raw(&mut self) -> Result<I16x3, AccelerometerError<Self::Error>> {
         let accel_bytes = self.read_accel_bytes()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,7 @@ where
     E: Debug,
 {
     /// Create a new LIS3DH driver from the given I2C peripheral. Default is
-    /// Hz_400 HighResolution. Note currently latches interrupt for INT1 by
-    /// default but that is deprecated and will need to be done manulaly by user
-    /// in future.
+    /// Hz_400 HighResolution.
     pub fn new(i2c: I2C, address: SlaveAddr) -> Result<Self, Error<E>> {
         let mut lis3dh = Lis3dh {
             i2c,
@@ -71,9 +69,6 @@ where
 
         // Enable ADCs.
         lis3dh.write_register(Register::TEMP_CFG, ADC_EN)?;
-
-        // Latch interrupt for INT1
-        lis3dh.write_register(Register::CTRL5, 0x08)?;
 
         Ok(lis3dh)
     }
@@ -162,12 +157,6 @@ where
         let odr = (ctrl1 >> 4) & 0x0F;
 
         DataRate::try_from(odr).map_err(|_| Error::InvalidDataRate)
-    }
-
-    /// High-resolution output mode.
-    /// `CTRL_REG4`: `HR`
-    pub fn set_hr(&mut self, hr: bool) -> Result<(), Error<E>> {
-        self.register_xset_bits(Register::CTRL4, HR, hr)
     }
 
     /// Full-scale selection

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use core::fmt::Debug;
 
 use accelerometer::error::Error as AccelerometerError;
 use accelerometer::vector::{F32x3, I16x3};
-use accelerometer::{Accelerometer, RawAccelerometer, Tracker};
+use accelerometer::{Accelerometer, RawAccelerometer};
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 
 mod register;
@@ -242,15 +242,6 @@ where
         let value = ((out_h as i16) << 2) | ((out_l as i16) >> 6);
 
         Ok((value as f32) * 0.25)
-    }
-
-    /// Use this accelerometer as an orientation tracker
-    pub fn try_into_tracker(&mut self) -> Result<Tracker, Error<E>> {
-        self.set_range(Range::G8)?;
-
-        // The `threshold` value was obtained experimentally, as per the
-        // recommendations made in the datasheet.
-        Ok(Tracker::new(3700.0))
     }
 
     /// Modify a register's value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,15 @@ where
     }
 
     /// Operating mode selection.
-    /// `CTRL_REG1`: `LPen` bit, `CTRL_REG4`: `HR` bit
+    /// `CTRL_REG1`: `LPen` bit, `CTRL_REG4`: `HR` bit.
+    /// You need to wait for stabilization after setting. In future this fn will
+    /// be deprecated and instead take a delay to do this for you.
+    /// HighResolution to LowPower 1/datarate
+    /// HighResolution -> Normal 1/datarate
+    /// Normal -> LowPower 1/datarate
+    /// Normal -> HighResolution 7/datarate
+    /// LowPower -> Normal 1/datarate
+    /// LowPower -> HighResolution 7/datarate
     pub fn set_mode(&mut self, mode: Mode) -> Result<(), Error<E>> {
         match mode {
             Mode::LowPower => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 use core::convert::{TryFrom, TryInto};
 use core::fmt::Debug;
 
-use accelerometer;
 use accelerometer::error::Error as AccelerometerError;
 use accelerometer::vector::{F32x3, I16x3};
 use accelerometer::{Accelerometer, RawAccelerometer, Tracker};
@@ -357,13 +356,6 @@ where
     /// Get the sample rate of the accelerometer data
     fn sample_rate(&mut self) -> Result<f32, AccelerometerError<Self::Error>> {
         let sample_rate = match self.get_datarate()? {
-            DataRate::Hz_1344_LP5k => {
-                if self.get_mode()? == Mode::LowPower {
-                    5376.0
-                } else {
-                    1344.0
-                }
-            }
             DataRate::Hz_400 => 400.0,
             DataRate::Hz_200 => 200.0,
             DataRate::Hz_100 => 100.0,
@@ -372,7 +364,6 @@ where
             DataRate::Hz_10 => 10.0,
             DataRate::Hz_1 => 1.0,
             DataRate::PowerDown => 0.0,
-            DataRate::LowPower_1K6HZ => 1600.0,
         };
 
         Ok(sample_rate)

--- a/src/register.rs
+++ b/src/register.rs
@@ -151,12 +151,6 @@ pub enum DataRate {
 
     /// Power down
     PowerDown = 0b0000,
-
-    /// Low power mode (1.6KHz)
-    LowPower_1K6HZ = 0b1000,
-
-    /// # Normal power mode (1344Hz) / Low power mode (5KHz)
-    Hz_1344_LP5k = 0b1001,
 }
 
 impl DataRate {


### PR DESCRIPTION
From previous conversation. Breaking change is the smallest breaking change option. Mode and data rate are intermingled for 2 modes (probably not widely used). A far larger breaking change would be to refactor and have mode and rate be set with the same function, maybe even the same enum like HR1hz, Low1hz, normal1hz, low5.376hz.  Or maybe an low(1hz), low(5.376hz)

8.8 Table 31
ODR
0000 Power-down mode
0001 HR / Normal / Low-power mode (1 Hz)
0010 HR / Normal / Low-power mode (10 Hz)
0011 HR / Normal / Low-power mode (25 Hz)
0100 HR / Normal / Low-power mode (50 Hz)
0101 HR / Normal / Low-power mode (100 Hz)
0110 HR / Normal / Low-power mode (200 Hz)
0111 HR / Normal / Low-power mode (400 Hz)
1000 Low power mode (1.60 kHz)
1001HR / normal (1.344 kHz);
Low-power mode (5.376 kHz)


Further cleanup is to document that enabling interrupts silently in the new probably isnt ideal and should go away some day. Also previously we set Normal mode, then manually set high resolution mode after. This just sets High resolution mode explicitly and once.
