### PR TITLE
Fix `accel_norm` and `get_temp_outf` implementations, improved docs

### DIFF
--- a/examples/cpx.rs
+++ b/examples/cpx.rs
@@ -4,7 +4,7 @@
 use circuit_playground_express as hal;
 extern crate panic_halt;
 
-use accelerometer::RawAccelerometer;
+use accelerometer::{RawAccelerometer, Tracker};
 use cortex_m_rt::entry;
 use cortex_m_semihosting::hprintln;
 use hal::clock::GenericClockController;
@@ -42,7 +42,7 @@ fn main() -> ! {
     lis3dh.set_range(lis3dh::Range::G8).unwrap();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let mut tracker = lis3dh.try_into_tracker().unwrap();
+    let mut tracker = Tracker::new(3700.0);
 
     loop {
         let accel = lis3dh.accel_raw().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,20 +244,6 @@ where
         Ok((value as f32) * 0.25)
     }
 
-    /// Reboot memory content.
-    /// `CTRL_REG5`: `BOOT`
-    pub fn reboot(&mut self, reboot: bool) -> Result<(), Error<E>> {
-        self.register_xset_bits(Register::CTRL5, BOOT, reboot)
-    }
-
-    /// In boot,
-    /// `CTRL_REG5`: `BOOT`
-    pub fn is_in_boot(&mut self) -> Result<bool, Error<E>> {
-        let ctrl5 = self.read_register(Register::CTRL5)?;
-
-        Ok((ctrl5 & BOOT) != 0)
-    }
-
     /// Use this accelerometer as an orientation tracker
     pub fn try_into_tracker(&mut self) -> Result<Tracker, Error<E>> {
         self.set_range(Range::G8)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,9 @@ where
 {
     type Error = Error<E>;
 
-    /// Get normalized ±g reading from the accelerometer
+    /// Get normalized ±g reading from the accelerometer. You should be reading
+    /// based on data ready interrupt or if reading in a tight loop you should
+    /// waiting for `is_data_ready`
     fn accel_norm(&mut self) -> Result<F32x3, AccelerometerError<Self::Error>> {
         let acc_raw: I16x3 = self.accel_raw()?;
         let sensitivity = match self.get_range()? {
@@ -384,7 +386,9 @@ where
 {
     type Error = Error<E>;
 
-    /// Get raw acceleration data from the accelerometer.
+    /// Get raw acceleration data from the accelerometer. You should be reading
+    /// based on data ready interrupt or if reading in a tight loop you should
+    /// waiting for `is_data_ready`
     fn accel_raw(&mut self) -> Result<I16x3, AccelerometerError<Self::Error>> {
         let accel_bytes = self.read_accel_bytes()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,7 @@ where
     E: Debug,
 {
     /// Create a new LIS3DH driver from the given I2C peripheral. Default is
-    /// Hz_400 HighResolution. Note currently latches interrupt for INT1 by
-    /// default but that is deprecated and will need to be done manulaly by user
-    /// in future.
+    /// Hz_400 HighResolution.
     pub fn new(i2c: I2C, address: SlaveAddr) -> Result<Self, Error<E>> {
         let mut lis3dh = Lis3dh {
             i2c,
@@ -71,9 +69,6 @@ where
 
         // Enable ADCs.
         lis3dh.write_register(Register::TEMP_CFG, ADC_EN)?;
-
-        // Latch interrupt for INT1
-        lis3dh.write_register(Register::CTRL5, 0x08)?;
 
         Ok(lis3dh)
     }
@@ -162,12 +157,6 @@ where
         let odr = (ctrl1 >> 4) & 0x0F;
 
         DataRate::try_from(odr).map_err(|_| Error::InvalidDataRate)
-    }
-
-    /// High-resolution output mode.
-    /// `CTRL_REG4`: `HR`
-    pub fn set_hr(&mut self, hr: bool) -> Result<(), Error<E>> {
-        self.register_xset_bits(Register::CTRL4, HR, hr)
     }
 
     /// Full-scale selection

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,15 @@
 use core::convert::{TryFrom, TryInto};
 use core::fmt::Debug;
 
+pub use accelerometer;
 use accelerometer::error::Error as AccelerometerError;
 use accelerometer::vector::{F32x3, I16x3};
 use accelerometer::{Accelerometer, RawAccelerometer};
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 
 mod register;
-pub use register::*;
+use register::*;
+pub use register::{DataRate, DataStatus, Mode, Range, SlaveAddr};
 
 /// Accelerometer errors, generic around another error type `E` representing
 /// an (optional) cause of this error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use core::fmt::Debug;
 
 use accelerometer::error::Error as AccelerometerError;
 use accelerometer::vector::{F32x3, I16x3};
-use accelerometer::{Accelerometer, RawAccelerometer, Tracker};
+use accelerometer::{Accelerometer, RawAccelerometer};
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 
 mod register;
@@ -242,15 +242,6 @@ where
         let value = ((out_h as i16) << 2) | ((out_l as i16) >> 6);
 
         Ok((value as f32) * 0.25)
-    }
-
-    /// Use this accelerometer as an orientation tracker
-    pub fn try_into_tracker(&mut self) -> Result<Tracker, Error<E>> {
-        self.set_range(Range::G8)?;
-
-        // The `threshold` value was obtained experimentally, as per the
-        // recommendations made in the datasheet.
-        Ok(Tracker::new(3700.0))
     }
 
     /// Modify a register's value

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ where
 
     /// X,Y,Z-axis enable.
     /// `CTRL_REG1`: `Xen`, `Yen`, `Zen`
-    pub fn enable_axis(&mut self, (x, y, z): (bool, bool, bool)) -> Result<(), Error<E>> {
+    fn enable_axis(&mut self, (x, y, z): (bool, bool, bool)) -> Result<(), Error<E>> {
         self.modify_register(Register::CTRL1, |mut ctrl1| {
             ctrl1 &= !(X_EN | Y_EN | Z_EN); // disable all axes
 
@@ -368,7 +368,9 @@ where
 
         // Depending on which Mode we are operating in, the data has different
         // resolution. Using this knowledge, we determine how many bits the
-        // data needs to be shifted.
+        // data needs to be shifted. This is necessary because the raw data
+        // is in left-justified two's complement and we would like for it to be
+        // right-justified instead.
         let shift: u8 = match mode {
             Mode::HighResolution => 4, // High Resolution:  12-bit
             Mode::Normal => 6,         // Normal:           10-bit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,15 @@ where
     }
 
     /// Operating mode selection.
-    /// `CTRL_REG1`: `LPen` bit, `CTRL_REG4`: `HR` bit
+    /// `CTRL_REG1`: `LPen` bit, `CTRL_REG4`: `HR` bit.
+    /// You need to wait for stabilization after setting. In future this fn will
+    /// be deprecated and instead take a delay to do this for you.
+    /// HighResolution to LowPower 1/datarate
+    /// HighResolution -> Normal 1/datarate
+    /// Normal -> LowPower 1/datarate
+    /// Normal -> HighResolution 7/datarate
+    /// LowPower -> Normal 1/datarate
+    /// LowPower -> HighResolution 7/datarate
     pub fn set_mode(&mut self, mode: Mode) -> Result<(), Error<E>> {
         match mode {
             Mode::LowPower => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 use core::convert::{TryFrom, TryInto};
 use core::fmt::Debug;
 
-use accelerometer;
 use accelerometer::error::Error as AccelerometerError;
 use accelerometer::vector::{F32x3, I16x3};
 use accelerometer::{Accelerometer, RawAccelerometer, Tracker};
@@ -357,13 +356,6 @@ where
     /// Get the sample rate of the accelerometer data
     fn sample_rate(&mut self) -> Result<f32, AccelerometerError<Self::Error>> {
         let sample_rate = match self.get_datarate()? {
-            DataRate::Hz_1344_LP5k => {
-                if self.get_mode()? == Mode::LowPower {
-                    5376.0
-                } else {
-                    1344.0
-                }
-            }
             DataRate::Hz_400 => 400.0,
             DataRate::Hz_200 => 200.0,
             DataRate::Hz_100 => 100.0,
@@ -372,7 +364,6 @@ where
             DataRate::Hz_10 => 10.0,
             DataRate::Hz_1 => 1.0,
             DataRate::PowerDown => 0.0,
-            DataRate::LowPower_1K6HZ => 1600.0,
         };
 
         Ok(sample_rate)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 //! Platform-agnostic LIS3DH accelerometer driver which uses I²C via
 //! [embedded-hal]. This driver implements the [`Accelerometer`][acc-trait]
-//! and [`RawAccelerometer`][raw-trait] traits from the `accelerometer` crate.
+//! and [`RawAccelerometer`][raw-trait] traits from the [accelerometer] crate.
 //!
 //! [embedded-hal]: https://docs.rs/embedded-hal
+//! [accelerometer]: https://docs.rs/accelerometer
 //! [acc-trait]: https://docs.rs/accelerometer/latest/accelerometer/trait.Accelerometer.html
 //! [raw-trait]: https://docs.rs/accelerometer/latest/accelerometer/trait.RawAccelerometer.html
 //!
@@ -20,19 +21,30 @@ use embedded_hal::blocking::i2c::{Write, WriteRead};
 mod register;
 pub use register::*;
 
+/// Accelerometer errors, generic around another error type `E` representing
+/// an (optional) cause of this error.
 #[derive(Debug)]
 pub enum Error<E> {
     /// I²C bus error
     I2C(E),
-    /// Invalid input data.
+
+    /// Invalid data rate selection
     InvalidDataRate,
+
+    /// Invalid operating mode selection
     InvalidMode,
+
+    /// Invalid full-scale selection
     InvalidRange,
+
+    /// Attempted to write to a read-only register
     WriteToReadOnly,
+
+    /// Invalid address provided
     WrongAddress,
 }
 
-/// `LIS3DH` driver
+/// `LIS3DH` driver.
 pub struct Lis3dh<I2C> {
     /// Underlying I²C device
     i2c: I2C,
@@ -73,7 +85,12 @@ where
         Ok(lis3dh)
     }
 
-    /// `WHO_AM_I` register
+    /// Destroy driver instance, returning `I2C` bus instance.
+    pub fn destroy(self) -> I2C {
+        self.i2c
+    }
+
+    /// `WHO_AM_I` register.
     pub fn get_device_id(&mut self) -> Result<u8, Error<E>> {
         self.read_register(Register::WHOAMI)
     }
@@ -92,16 +109,20 @@ where
         })
     }
 
-    /// Operating mode selection.
-    /// `CTRL_REG1`: `LPen` bit, `CTRL_REG4`: `HR` bit.
-    /// You need to wait for stabilization after setting. In future this fn will
-    /// be deprecated and instead take a delay to do this for you.
-    /// HighResolution to LowPower 1/datarate
-    /// HighResolution -> Normal 1/datarate
-    /// Normal -> LowPower 1/datarate
-    /// Normal -> HighResolution 7/datarate
-    /// LowPower -> Normal 1/datarate
-    /// LowPower -> HighResolution 7/datarate
+    /// Operating mode selection.  
+    /// `CTRL_REG1`: `LPen` bit, `CTRL_REG4`: `HR` bit.  
+    /// You need to wait for stabilization after setting. In future this
+    /// function will be deprecated and instead take a `Delay` to do this for
+    /// you.
+    ///
+    /// | From           | To             | Wait for   |
+    /// |:---------------|:---------------|:-----------|
+    /// | HighResolution | LowPower       | 1/datarate |
+    /// | HighResolution | Normal         | 1/datarate |
+    /// | Normal         | LowPower       | 1/datarate |
+    /// | Normal         | HighResolution | 7/datarate |
+    /// | LowPower       | Normal         | 1/datarate |
+    /// | LowPower       | HighResolution | 7/datarate |
     pub fn set_mode(&mut self, mode: Mode) -> Result<(), Error<E>> {
         match mode {
             Mode::LowPower => {
@@ -121,15 +142,15 @@ where
         Ok(())
     }
 
-    /// Read the current operating mode
+    /// Read the current operating mode.
     pub fn get_mode(&mut self) -> Result<Mode, Error<E>> {
         let ctrl1 = self.read_register(Register::CTRL1)?;
         let ctrl4 = self.read_register(Register::CTRL4)?;
 
-        let lp = (ctrl1 >> 3) & 0x01 != 0;
-        let hr = (ctrl4 >> 3) & 0x01 != 0;
+        let is_lp_set = (ctrl1 >> 3) & 0x01 != 0;
+        let is_hr_set = (ctrl4 >> 3) & 0x01 != 0;
 
-        let mode = match (lp, hr) {
+        let mode = match (is_lp_set, is_hr_set) {
             (true, false) => Mode::LowPower,
             (false, false) => Mode::Normal,
             (false, true) => Mode::HighResolution,
@@ -139,7 +160,7 @@ where
         Ok(mode)
     }
 
-    /// Data rate selection
+    /// Data rate selection.
     pub fn set_datarate(&mut self, datarate: DataRate) -> Result<(), Error<E>> {
         self.modify_register(Register::CTRL1, |mut ctrl1| {
             // Mask off lowest 4 bits
@@ -151,7 +172,7 @@ where
         })
     }
 
-    /// Read the current data selection rate
+    /// Read the current data selection rate.
     pub fn get_datarate(&mut self) -> Result<DataRate, Error<E>> {
         let ctrl1 = self.read_register(Register::CTRL1)?;
         let odr = (ctrl1 >> 4) & 0x0F;
@@ -159,7 +180,7 @@ where
         DataRate::try_from(odr).map_err(|_| Error::InvalidDataRate)
     }
 
-    /// Full-scale selection
+    /// Full-scale selection.
     pub fn set_range(&mut self, range: Range) -> Result<(), Error<E>> {
         self.modify_register(Register::CTRL4, |mut ctrl4| {
             // Mask off lowest 4 bits
@@ -171,7 +192,7 @@ where
         })
     }
 
-    /// Read the current full-scale
+    /// Read the current full-scale.
     pub fn get_range(&mut self) -> Result<Range, Error<E>> {
         let ctrl4 = self.read_register(Register::CTRL4)?;
         let fs = (ctrl4 >> 4) & 0x03;
@@ -179,20 +200,17 @@ where
         Range::try_from(fs).map_err(|_| Error::InvalidRange)
     }
 
-    /// Set `REFERENCE` register
+    /// Set `REFERENCE` register.
     pub fn set_ref(&mut self, reference: u8) -> Result<(), Error<E>> {
         self.write_register(Register::REFERENCE, reference)
     }
 
-    /// Read the `REFERENCE` register
+    /// Read the `REFERENCE` register.
     pub fn get_ref(&mut self) -> Result<u8, Error<E>> {
         self.read_register(Register::REFERENCE)
     }
 
-    /// Data status.
-    /// `STATUS_REG`: as
-    /// DataStatus { zyxor: `ZYXOR`, xyzor: (`XOR`, `YOR`, `ZOR`),
-    ///              zyxda: `ZYXDA`, xyzda: (`XDA`, `YDA`, `ZDA`) }
+    /// Accelerometer data-available status.
     pub fn get_status(&mut self) -> Result<DataStatus, Error<E>> {
         let stat = self.read_register(Register::STATUS)?;
 
@@ -206,16 +224,17 @@ where
 
     /// Convenience function for `STATUS_REG` to confirm all three X, Y and
     /// Z-axis have new data available for reading by accel_raw and associated
-    /// function calls
+    /// function calls.
     pub fn is_data_ready(&mut self) -> Result<bool, Error<E>> {
         let value = self.get_status()?;
+
         Ok(value.zyxda)
     }
 
     /// Temperature sensor enable.
-    /// `TEMP_CGF_REG`: `TEMP_EN`, the BDU bit in `CTRL_REG4` is also set
+    /// `TEMP_CGF_REG`: `TEMP_EN`, the BDU bit in `CTRL_REG4` is also set.
     pub fn enable_temp(&mut self, enable: bool) -> Result<(), Error<E>> {
-        self.register_xset_bits(Register::TEMP_CFG, TEMP_EN, enable)?;
+        self.register_xset_bits(Register::TEMP_CFG, ADC_EN & TEMP_EN, enable)?;
 
         // enable block data update (required for temp reading)
         if enable {
@@ -225,42 +244,48 @@ where
         Ok(())
     }
 
-    /// Temperature sensor data.
-    /// `OUT_TEMP_H`, `OUT_TEMP_L`
-    pub fn get_temp_out(&mut self) -> Result<(i8, u8), Error<E>> {
-        let out_l = self.read_register(Register::OUT_ADC2_L)?;
-        let out_h = self.read_register(Register::OUT_ADC2_H)?;
+    /// Raw temperature sensor data as `i16`. The temperature sensor __must__
+    /// be enabled via `enable_temp` prior to reading.
+    pub fn get_temp_out(&mut self) -> Result<i16, Error<E>> {
+        let out_l = self.read_register(Register::OUT_ADC3_L)?;
+        let out_h = self.read_register(Register::OUT_ADC3_H)?;
 
-        Ok((out_h as i8, out_l))
+        Ok(i16::from_le_bytes([out_l, out_h]))
     }
 
-    /// Temperature sensor data converted to f32.
-    /// `OUT_TEMP_H`, `OUT_TEMP_L`
+    /// Temperature sensor data converted to `f32`. Output is in degree
+    /// celsius. The temperature sensor __must__ be enabled via `enable_temp`
+    /// prior to reading.
     pub fn get_temp_outf(&mut self) -> Result<f32, Error<E>> {
-        let (out_h, out_l) = self.get_temp_out()?;
-        // 10-bit resolution
-        let value = ((out_h as i16) << 2) | ((out_l as i16) >> 6);
+        let temp_out = self.get_temp_out()?;
 
-        Ok((value as f32) * 0.25)
+        Ok(temp_out as f32 / 256.0 + 25.0)
     }
 
-    /// Modify a register's value
+    /// Modify a register's value. Read the current value of the register,
+    /// update the value with the provided function, and set the register to
+    /// the return value.
     fn modify_register<F>(&mut self, register: Register, f: F) -> Result<(), Error<E>>
     where
         F: FnOnce(u8) -> u8,
     {
         let value = self.read_register(register)?;
+
         self.write_register(register, f(value))
     }
 
+    /// Clear the given bits in the given register.
     fn register_clear_bits(&mut self, reg: Register, bits: u8) -> Result<(), Error<E>> {
         self.modify_register(reg, |v| v & !bits)
     }
 
+    /// Set the given bits in the given register.
     fn register_set_bits(&mut self, reg: Register, bits: u8) -> Result<(), Error<E>> {
         self.modify_register(reg, |v| v | bits)
     }
 
+    /// Set or clear the given given bits in the given register, depending on
+    /// the value of `set`.
     fn register_xset_bits(&mut self, reg: Register, bits: u8, set: bool) -> Result<(), Error<E>> {
         if set {
             self.register_set_bits(reg, bits)
@@ -269,7 +294,7 @@ where
         }
     }
 
-    /// Read from the registers for each of the 3 axes
+    /// Read from the registers for each of the 3 axes.
     fn read_accel_bytes(&mut self) -> Result<[u8; 6], Error<E>> {
         let mut data = [0u8; 6];
 
@@ -279,7 +304,7 @@ where
             .and(Ok(data))
     }
 
-    /// Write to the given register
+    /// Write a byte to the given register.
     fn write_register(&mut self, register: Register, value: u8) -> Result<(), Error<E>> {
         if register.read_only() {
             return Err(Error::WriteToReadOnly);
@@ -290,7 +315,7 @@ where
             .map_err(Error::I2C)
     }
 
-    /// Read from the given register
+    /// Read a byte from the given register.
     fn read_register(&mut self, register: Register) -> Result<u8, Error<E>> {
         let mut data = [0];
 
@@ -310,7 +335,7 @@ where
 
     /// Get normalized ±g reading from the accelerometer. You should be reading
     /// based on data ready interrupt or if reading in a tight loop you should
-    /// waiting for `is_data_ready`
+    /// waiting for `is_data_ready`.
     fn accel_norm(&mut self) -> Result<F32x3, AccelerometerError<Self::Error>> {
         // The official driver from ST was used as a reference.
         // https://github.com/STMicroelectronics/STMems_Standard_C_drivers/tree/master/lis3dh_STdC
@@ -356,7 +381,7 @@ where
         Ok(F32x3::new(x, y, z))
     }
 
-    /// Get the sample rate of the accelerometer data
+    /// Get the sample rate of the accelerometer data.
     fn sample_rate(&mut self) -> Result<f32, AccelerometerError<Self::Error>> {
         Ok(self.get_datarate()?.sample_rate())
     }
@@ -371,7 +396,7 @@ where
 
     /// Get raw acceleration data from the accelerometer. You should be reading
     /// based on data ready interrupt or if reading in a tight loop you should
-    /// waiting for `is_data_ready`
+    /// waiting for `is_data_ready`.
     fn accel_raw(&mut self) -> Result<I16x3, AccelerometerError<Self::Error>> {
         let accel_bytes = self.read_accel_bytes()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,6 @@ where
         Ok(lis3dh)
     }
 
-    /// Destroy driver instance, returning `I2C` bus instance.
-    pub fn destroy(self) -> I2C {
-        self.i2c
-    }
-
     /// `WHO_AM_I` register.
     pub fn get_device_id(&mut self) -> Result<u8, Error<E>> {
         self.read_register(Register::WHOAMI)

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,6 +1,6 @@
 use num_enum::TryFromPrimitive;
 
-/// Possible I²C slave addresses
+/// Possible I²C slave addresses.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum SlaveAddr {
@@ -17,8 +17,8 @@ impl SlaveAddr {
     }
 }
 
-/// Enumerate all device registers
-#[allow(non_camel_case_types)]
+/// Enumerate all device registers.
+#[allow(dead_code, non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Register {
@@ -99,7 +99,7 @@ impl Register {
     }
 }
 
-/// Full-scale selection
+/// Full-scale selection.
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
@@ -123,7 +123,7 @@ impl Range {
     }
 }
 
-/// Output data rate
+/// Output data rate.
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
@@ -204,7 +204,7 @@ pub struct DataStatus {
     pub xyzda: (bool, bool, bool),
 }
 
-/// Operating mode
+/// Operating mode.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum Mode {
@@ -241,10 +241,6 @@ pub const X_EN: u8 = 0b0000_0001;
 pub const BDU: u8 = 0b1000_0000;
 pub const FS_MASK: u8 = 0b0011_0000;
 pub const HR: u8 = 0b0000_1000;
-
-// === CTRL_REG5 (24h) ===
-
-pub const BOOT: u8 = 0b1000_0000;
 
 // === STATUS_REG (27h) ===
 

--- a/src/register.rs
+++ b/src/register.rs
@@ -151,12 +151,6 @@ pub enum DataRate {
 
     /// Power down
     PowerDown = 0b0000,
-
-    /// Low power mode (1.6KHz)
-    LowPower_1K6HZ = 0b1000,
-
-    /// # Normal power mode (1344Hz) / Low power mode (5KHz)
-    Hz_1344_LP5k = 0b1001,
 }
 
 impl DataRate {

--- a/src/register.rs
+++ b/src/register.rs
@@ -157,6 +157,19 @@ impl DataRate {
     pub fn bits(self) -> u8 {
         self as u8
     }
+
+    pub fn sample_rate(self) -> f32 {
+        match self {
+            DataRate::Hz_400 => 400.0,
+            DataRate::Hz_200 => 200.0,
+            DataRate::Hz_100 => 100.0,
+            DataRate::Hz_50 => 50.0,
+            DataRate::Hz_25 => 25.0,
+            DataRate::Hz_10 => 10.0,
+            DataRate::Hz_1 => 1.0,
+            DataRate::PowerDown => 0.0,
+        }
+    }
 }
 
 /// Data status structure. Decoded from the `STATUS_REG` register.


### PR DESCRIPTION
This is based off of #5, ~~so once that has been merged this should be pretty much ready to go as well~~. Changes include:

- `accel_norm` now properly takes into account the current `Mode` and `Range`
- sample rate values are provided from a function in the `DataRate` impl rather than being computed in `sample_rate`
- temperature conversion is now correct (in accordance with the official ST driver)
- additional and more consistent documentation, public exports cleaned up
- warnings fixed