### PR TITLE
Expose Interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.4.2
+* Interrupt support, adding methods
+    
+    - `configure_interrupt_pin`
+    - `configure_irq_src_and_control`
+    - `configure_irq_src`
+    - `configure_irq_duration`
+    - `configure_irq_threshold`
+    - `get_irq_src`
+    - `configure_switch_to_low_power`
+    - `configure_irq_src_and_control`
+
 # 0.4.1
 * Spi support
 * BREAKING - new method has been replaced by new_i2c or new_spi.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Platform-agnostic Rust driver for the ST LIS3DH 3-axis MEMS "nano" accelerometer
 - [LIS3DH product page][product-page]
 - [LIS3DH datasheet][datasheet]
 
+### Examples
+
+- [CPX](https://github.com/BenBergman/lis3dh-rs/blob/master/examples/cpx.rs)
+- [Interrupts](https://github.com/tweedegolf/lis3dh-interrupt-demo)
+
 ## License
 
 Dual licensed under your choice of either of:

--- a/examples/cpx.rs
+++ b/examples/cpx.rs
@@ -38,7 +38,7 @@ fn main() -> ! {
         pins.accel_scl.into_pad(&mut pins.port),
     );
 
-    let mut lis3dh = Lis3dh::new(i2c, SlaveAddr::Alternate).unwrap();
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).unwrap();
     lis3dh.set_range(lis3dh::Range::G8).unwrap();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,0 +1,201 @@
+use crate::register::*;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Interrupt1;
+
+#[derive(Debug, Copy, Clone)]
+pub struct Interrupt2;
+
+pub trait Interrupt {
+    fn cfg_reg() -> Register;
+    fn ths_reg() -> Register;
+    fn src_reg() -> Register;
+    fn duration_reg() -> Register;
+    fn lir_int_bit() -> u8;
+    fn d4d_int_bit() -> u8;
+}
+
+impl Interrupt for Interrupt1 {
+    fn cfg_reg() -> Register {
+        Register::INT1_CFG
+    }
+
+    fn ths_reg() -> Register {
+        Register::INT1_THS
+    }
+
+    fn src_reg() -> Register {
+        Register::INT1_SRC
+    }
+
+    fn duration_reg() -> Register {
+        Register::INT1_DURATION
+    }
+
+    fn lir_int_bit() -> u8 {
+        3
+    }
+
+    fn d4d_int_bit() -> u8 {
+        2
+    }
+}
+
+impl Interrupt for Interrupt2 {
+    fn cfg_reg() -> Register {
+        Register::INT2_CFG
+    }
+
+    fn ths_reg() -> Register {
+        Register::INT2_THS
+    }
+
+    fn src_reg() -> Register {
+        Register::INT2_SRC
+    }
+
+    fn duration_reg() -> Register {
+        Register::INT2_DURATION
+    }
+
+    fn lir_int_bit() -> u8 {
+        1
+    }
+
+    fn d4d_int_bit() -> u8 {
+        0
+    }
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct InterruptSource {
+    pub and_or_combination: bool,
+    pub interrupt_active: bool,
+
+    pub z_axis_high: bool,
+    pub z_axis_low: bool,
+
+    pub y_axis_high: bool,
+    pub y_axis_low: bool,
+
+    pub x_axis_high: bool,
+    pub x_axis_low: bool,
+}
+
+impl InterruptSource {
+    pub const fn all() -> Self {
+        Self {
+            and_or_combination: true,
+            interrupt_active: true,
+
+            z_axis_high: true,
+            z_axis_low: true,
+
+            y_axis_high: true,
+            y_axis_low: true,
+
+            x_axis_high: true,
+            x_axis_low: true,
+        }
+    }
+
+    pub const fn high() -> Self {
+        Self {
+            and_or_combination: true,
+            interrupt_active: true,
+
+            z_axis_high: true,
+            z_axis_low: false,
+
+            y_axis_high: true,
+            y_axis_low: false,
+
+            x_axis_high: true,
+            x_axis_low: false,
+        }
+    }
+
+    pub const fn low() -> Self {
+        Self {
+            and_or_combination: true,
+            interrupt_active: true,
+
+            z_axis_high: false,
+            z_axis_low: true,
+
+            y_axis_high: false,
+            y_axis_low: true,
+
+            x_axis_high: false,
+            x_axis_low: true,
+        }
+    }
+
+    pub const fn bits(self) -> u8 {
+        (self.and_or_combination as u8) << 7
+            | (self.interrupt_active as u8) << 6
+            | (self.z_axis_high as u8) << 5
+            | (self.z_axis_low as u8) << 4
+            | (self.y_axis_high as u8) << 3
+            | (self.y_axis_low as u8) << 2
+            | (self.x_axis_high as u8) << 1
+            | (self.x_axis_low as u8) << 0
+    }
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct IrqPin1Conf {
+    pub click_en: bool,    // 7
+    pub ia1_en: bool,      // 6
+    pub ia2_en: bool,      // 5
+    pub zyxda_en: bool,    // 4
+    pub adc321da_en: bool, // 3
+    pub wtm_en: bool,      // 2
+    pub overrun_en: bool,  // 1
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct IrqPin2Conf {
+    pub click_en: bool,   // 7
+    pub ia1_en: bool,     // 6
+    pub ia2_en: bool,     // 5
+    pub boot_en: bool,    // 4
+    pub act_en: bool,     // 3
+    pub active_low: bool, // 1
+}
+
+pub trait IrqPin {
+    fn ctrl_reg() -> Register;
+    fn bits(self) -> u8;
+}
+
+impl IrqPin for IrqPin1Conf {
+    fn ctrl_reg() -> Register {
+        Register::CTRL3
+    }
+
+    fn bits(self) -> u8 {
+        (self.click_en as u8) << 7
+            | (self.ia1_en as u8) << 6
+            | (self.ia2_en as u8) << 5
+            | (self.zyxda_en as u8) << 4
+            | (self.adc321da_en as u8) << 3
+            | (self.wtm_en as u8) << 2
+            | (self.overrun_en as u8) << 1
+    }
+}
+
+impl IrqPin for IrqPin2Conf {
+    fn ctrl_reg() -> Register {
+        Register::CTRL6
+    }
+
+    fn bits(self) -> u8 {
+        (self.click_en as u8) << 7
+            | (self.ia1_en as u8) << 6
+            | (self.ia2_en as u8) << 5
+            | (self.boot_en as u8) << 4
+            | (self.act_en as u8) << 3
+            | (self.active_low as u8) << 1
+    }
+}

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -219,7 +219,7 @@ impl InterruptConfig {
 
 #[derive(Debug, Copy, Clone, Default)]
 #[doc(alias = "CTRL_REG3")]
-pub struct IrqPin1Conf {
+pub struct IrqPin1Config {
     pub click_en: bool,    // 7
     pub ia1_en: bool,      // 6
     pub ia2_en: bool,      // 5
@@ -231,7 +231,7 @@ pub struct IrqPin1Conf {
 
 #[derive(Debug, Copy, Clone, Default)]
 #[doc(alias = "CTRL_REG6")]
-pub struct IrqPin2Conf {
+pub struct IrqPin2Config {
     pub click_en: bool,   // 7
     pub ia1_en: bool,     // 6
     pub ia2_en: bool,     // 5
@@ -245,7 +245,7 @@ pub trait IrqPin {
     fn bits(self) -> u8;
 }
 
-impl IrqPin for IrqPin1Conf {
+impl IrqPin for IrqPin1Config {
     fn ctrl_reg() -> Register {
         Register::CTRL3
     }
@@ -261,7 +261,7 @@ impl IrqPin for IrqPin1Conf {
     }
 }
 
-impl IrqPin for IrqPin2Conf {
+impl IrqPin for IrqPin2Config {
     fn ctrl_reg() -> Register {
         Register::CTRL6
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod register;
 use interrupts::*;
 pub use interrupts::{
     Detect4D, Interrupt1, Interrupt2, InterruptConfig, InterruptMode, InterruptSource, IrqPin,
-    IrqPin1Conf, IrqPin2Conf, LatchInterruptRequest,
+    IrqPin1Config, IrqPin2Config, LatchInterruptRequest,
 };
 
 use register::*;
@@ -435,11 +435,11 @@ where
 
     /// Configure one of the interrupt pins
     ///
-    ///     lis3dh.configure_interrupt_pin(IrqPin1Conf {
+    ///     lis3dh.configure_interrupt_pin(IrqPin1Config {
     ///         // Raise if interrupt 1 is raised
     ///         ia1_en: true,
     ///         // Disable for all other interrupts
-    ///         ..IrqPin1Conf::default()
+    ///         ..IrqPin1Config::default()
     ///     })?;
     pub fn configure_interrupt_pin<P: IrqPin>(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,17 @@ use embedded_hal::blocking::spi::{self, Transfer};
 
 use embedded_hal::digital::v2::OutputPin;
 
+mod interrupts;
 mod register;
+
+use interrupts::*;
+pub use interrupts::{
+    Detect4D, Interrupt1, Interrupt2, InterruptConfig, InterruptMode, InterruptSource, IrqPin,
+    IrqPin1Conf, IrqPin2Conf, LatchInterruptRequest,
+};
+
 use register::*;
-pub use register::{DataRate, DataStatus, Mode, Range, SlaveAddr};
+pub use register::{DataRate, DataStatus, Duration, Mode, Range, SlaveAddr, Threshold};
 
 /// Accelerometer errors, generic around another error type `E` representing
 /// an (optional) cause of this error.
@@ -87,6 +95,14 @@ where
         i2c: I2C,
         address: SlaveAddr,
     ) -> Result<Self, Error<E, core::convert::Infallible>> {
+        Self::new_i2c_with_config(i2c, address, Configuration::default())
+    }
+
+    pub fn new_i2c_with_config(
+        i2c: I2C,
+        address: SlaveAddr,
+        config: Configuration,
+    ) -> Result<Self, Error<E, core::convert::Infallible>> {
         let core = Lis3dhI2C {
             i2c,
             address: address.addr(),
@@ -94,7 +110,7 @@ where
 
         let mut lis3dh = Lis3dh { core };
 
-        lis3dh.initialize()?;
+        lis3dh.initialize(config)?;
 
         Ok(lis3dh)
     }
@@ -137,11 +153,19 @@ where
     ///     // create and initialize the sensor
     ///     let lis3dh = Lis3dh::new_spi(spi, cs).unwrap();
     pub fn new_spi(spi: SPI, nss: NSS) -> Result<Self, Error<ESPI, ENSS>> {
+        Self::new_spi_with_config(spi, nss, Configuration::default())
+    }
+
+    pub fn new_spi_with_config(
+        spi: SPI,
+        nss: NSS,
+        config: Configuration,
+    ) -> Result<Self, Error<ESPI, ENSS>> {
         let core = Lis3dhSPI { spi, nss };
 
         let mut lis3dh = Lis3dh { core };
 
-        lis3dh.initialize()?;
+        lis3dh.initialize(config)?;
 
         Ok(lis3dh)
     }
@@ -151,25 +175,34 @@ impl<CORE> Lis3dh<CORE>
 where
     CORE: Lis3dhCore,
 {
-    fn initialize(&mut self) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+    /// Initalize the device given the configuration
+    fn initialize(
+        &mut self,
+        conf: Configuration,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
         if self.get_device_id()? != DEVICE_ID {
             return Err(Error::WrongAddress);
         }
 
-        // Block data update
-        self.write_register(Register::CTRL4, BDU)?;
+        if conf.block_data_update || conf.enable_temperature {
+            // Block data update
+            self.write_register(Register::CTRL4, BDU)?;
+        }
 
-        self.set_mode(Mode::HighResolution)?;
+        self.set_mode(conf.mode)?;
 
-        self.set_datarate(DataRate::Hz_400)?;
+        self.set_datarate(conf.datarate)?;
 
-        self.enable_axis((true, true, true))?;
+        self.enable_axis((conf.enable_x_axis, conf.enable_y_axis, conf.enable_z_axis))?;
+
+        if conf.enable_temperature {
+            self.enable_temp(true)?;
+        }
 
         // Enable ADCs.
-        self.write_register(Register::TEMP_CFG, ADC_EN)?;
-
-        Ok(())
+        self.write_register(Register::TEMP_CFG, ADC_EN)
     }
+
     /// `WHO_AM_I` register.
     pub fn get_device_id(&mut self) -> Result<u8, Error<CORE::BusError, CORE::PinError>> {
         self.read_register(Register::WHOAMI)
@@ -281,7 +314,7 @@ where
     /// Read the current full-scale.
     pub fn get_range(&mut self) -> Result<Range, Error<CORE::BusError, CORE::PinError>> {
         let ctrl4 = self.read_register(Register::CTRL4)?;
-        let fs = (ctrl4 >> 4) & 0x03;
+        let fs = (ctrl4 >> 4) & 0b0011;
 
         Range::try_from(fs).map_err(|_| Error::InvalidRange)
     }
@@ -398,6 +431,157 @@ where
         } else {
             self.register_clear_bits(reg, bits)
         }
+    }
+
+    /// Configure one of the interrupt pins
+    ///
+    ///     lis3dh.configure_interrupt_pin(IrqPin1Conf {
+    ///         // Raise if interrupt 1 is raised
+    ///         ia1_en: true,
+    ///         // Disable for all other interrupts
+    ///         ..IrqPin1Conf::default()
+    ///     })?;
+    pub fn configure_interrupt_pin<P: IrqPin>(
+        &mut self,
+        pin: P,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        self.write_register(P::ctrl_reg(), pin.bits())
+    }
+
+    /// Configure an IRQ source
+    ///
+    /// Example: configure interrupt 1 to fire when there is movement along any of the axes.
+    ///
+    ///     lis3dh.configure_irq_src(
+    ///         lis3dh::Interrupt1,
+    ///         lis3dh::InterruptMode::Movement,
+    ///         lis3dh::InterruptConfig::high_and_low(),
+    ///     )?;
+    pub fn configure_irq_src<I: Interrupt>(
+        &mut self,
+        int: I,
+        interrupt_mode: InterruptMode,
+        interrupt_config: InterruptConfig,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        self.configure_irq_src_and_control(
+            int,
+            interrupt_mode,
+            interrupt_config,
+            LatchInterruptRequest::default(),
+            Detect4D::default(),
+        )
+    }
+
+    /// Configure an IRQ source.
+    ///
+    /// LIS (latch interrupt request) will latch (keep active) the interrupt until the [`Lis3dh::get_irq_src`] is read.
+    ///
+    /// 4D detection is a subset of the 6D detection where detection on the Z axis is disabled.
+    /// This setting only has effect when the interrupt mode is either `Movement` or `Position`.
+    ///
+    /// Example: configure interrupt 1 to fire when there is movement along any of the axes.
+    ///
+    ///     lis3dh.configure_irq_src(
+    ///         lis3dh::Interrupt1,
+    ///         lis3dh::InterruptMode::Movement,
+    ///         lis3dh::InterruptConfig::high_and_low(),
+    ///         lis3dh::LatchInterruptRequest::Enable,
+    ///         lis3dh::Detect4D::Enable,
+    ///     )?;
+    pub fn configure_irq_src_and_control<I: Interrupt>(
+        &mut self,
+        _int: I,
+        interrupt_mode: InterruptMode,
+        interrupt_config: InterruptConfig,
+        latch_interrupt_request: LatchInterruptRequest,
+        detect_4d: Detect4D,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        let latch_interrupt_request =
+            matches!(latch_interrupt_request, LatchInterruptRequest::Enable);
+
+        let detect_4d = matches!(detect_4d, Detect4D::Enable);
+
+        if latch_interrupt_request || detect_4d {
+            let latch = (latch_interrupt_request as u8) << I::lir_int_bit();
+            let d4d = (detect_4d as u8) << I::d4d_int_bit();
+            self.register_set_bits(Register::CTRL5, latch | d4d)?;
+        }
+        self.write_register(I::cfg_reg(), interrupt_config.to_bits(interrupt_mode))
+    }
+
+    /// Set the minimum duration for the Interrupt event to be recognized.
+    ///
+    /// Example: the event has to last at least 25 miliseconds to be recognized.
+    ///
+    ///     // let mut lis3dh = ...
+    ///     let duration = Duration::miliseconds(DataRate::Hz_400, 25.0);
+    ///     lis3dh.configure_irq_duration(duration);
+    #[doc(alias = "INT1_DURATION")]
+    #[doc(alias = "INT2_DURATION")]
+    pub fn configure_irq_duration<I: Interrupt>(
+        &mut self,
+        _int: I,
+        duration: Duration,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        self.write_register(I::duration_reg(), duration.0)
+    }
+
+    /// Set the minimum magnitude for the Interrupt event to be recognized.
+    ///
+    /// Example: the event has have a magnitude of at least 1.1g to be recognized.
+    ///
+    ///     // let mut lis3dh = ...
+    ///     let threshold = Threshold::g(Range::G2, 1.1);
+    ///     lis3dh.configure_irq_threshold(threshold);
+    #[doc(alias = "INT1_THS")]
+    #[doc(alias = "INT2_THS")]
+    pub fn configure_irq_threshold<I: Interrupt>(
+        &mut self,
+        _int: I,
+        threshold: Threshold,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        self.write_register(I::ths_reg(), threshold.0)
+    }
+
+    /// Get interrupt source. The `interrupt_active` field is true when an interrupt is active.
+    /// The other fields specify what measurement caused the interrupt.
+    pub fn get_irq_src<I: Interrupt>(
+        &mut self,
+        _int: I,
+    ) -> Result<InterruptSource, Error<CORE::BusError, CORE::PinError>> {
+        let irq_src = self.read_register(I::src_reg())?;
+        Ok(InterruptSource::from_bits(irq_src))
+    }
+
+    /// Configure 'Sleep to wake' and 'Return to sleep' threshold and duration.
+    ///
+    /// The LIS3DH can be programmed to automatically switch to low-power mode upon recognition of a determined event.  
+    /// Once the event condition is over, the device returns back to the preset normal or highresolution mode.
+    ///
+    /// Example: enter low-power mode. When a measurement above 1.1g is registered, then wake up
+    /// for 25ms to send the data.
+    ///
+    ///     // let mut lis3dh = ...
+    ///
+    ///     let range = Range::default();
+    ///     let data_rate = DataRate::Hz_400;
+    ///     
+    ///     let threshold = Threshold::g(range, 1.1);
+    ///     let duration = Duration::miliseconds(data_rate, 25.0);
+    ///     
+    ///     lis3dh.configure_switch_to_low_power(threshold, duration)?;
+    ///     
+    ///     lis3dh.set_datarate(data_rate)?;
+    #[doc(alias = "ACT_THS")]
+    #[doc(alias = "ACT_DUR")]
+    #[doc(alias = "act")]
+    pub fn configure_switch_to_low_power(
+        &mut self,
+        threshold: Threshold,
+        duration: Duration,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        self.write_register(Register::ACT_THS, threshold.0 & 0b0111_1111)?;
+        self.write_register(Register::ACT_DUR, duration.0)
     }
 }
 


### PR DESCRIPTION
This PR exposes the interrupts of the lis3dh

Some notes

- this PR adds a bunch of new types that have to be exposed. Currently these types are re-exported in `lib.rs` but maybe the `interrupts` module should be `pub use` instead?

- I couldn't find a good place for a full interrupt example. It is possible to puzzle it together from the examples for various functions, but I'd like to include a full example somewhere. Is there a way for an example to influence the `.cargo/config` and the `memory.x`. Alternatively someone that has the hardware used for the current example could maybe make a full interrupt example? We can also publish the example via the @tweedegolf organization and link to it.

