### PR TITLE
Expose FIFO + Register

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -2,9 +2,9 @@
 
 [build]
 target = "thumbv6m-none-eabi"
-rustflags = [
-   "-C", "link-arg=-Tlink.x",
-]
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+rustflags = [
+   "-C", "link-arg=-Tlink.x",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,5 @@ circuit_playground_express = { version = "~0.7", features = ["use_semihosting"] 
 cortex-m-rt = "~0.6"
 cortex-m-semihosting = "~0.3"
 panic-halt = "~0.2"
+
+[workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,3 @@ circuit_playground_express = { version = "~0.7", features = ["use_semihosting"] 
 cortex-m-rt = "~0.6"
 cortex-m-semihosting = "~0.3"
 panic-halt = "~0.2"
-
-[workspace]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -908,6 +908,7 @@ where
 }
 
 /// Sensor configuration options
+#[derive(Debug, Clone, Copy)]
 pub struct Configuration {
     /// The operating mode, default [`Mode::HighResolution`].
     pub mode: Mode,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ where
 
         let mut lis3dh = Lis3dh { core };
 
-        lis3dh.initialize(config)?;
+        lis3dh.configure(config)?;
 
         Ok(lis3dh)
     }
@@ -165,7 +165,7 @@ where
 
         let mut lis3dh = Lis3dh { core };
 
-        lis3dh.initialize(config)?;
+        lis3dh.configure(config)?;
 
         Ok(lis3dh)
     }
@@ -176,7 +176,7 @@ where
     CORE: Lis3dhCore,
 {
     /// Initalize the device given the configuration
-    fn initialize(
+    pub fn configure(
         &mut self,
         conf: Configuration,
     ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use interrupts::{
 };
 
 use register::*;
-pub use register::{DataRate, DataStatus, Duration, Mode, Range, SlaveAddr, Threshold};
+pub use register::{DataRate, DataStatus, Duration, Mode, Range, Register, SlaveAddr, Threshold};
 
 /// Accelerometer errors, generic around another error type `E` representing
 /// an (optional) cause of this error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@ pub use interrupts::{
 };
 
 use register::*;
-pub use register::{DataRate, DataStatus, Duration, Mode, Range, Register, SlaveAddr, Threshold};
+pub use register::{
+    DataRate, DataStatus, Duration, FifoMode, FifoStatus, Mode, Range, Register, SlaveAddr,
+    Threshold,
+};
 
 /// Accelerometer errors, generic around another error type `E` representing
 /// an (optional) cause of this error.
@@ -590,6 +593,39 @@ where
     ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
         self.write_register(Register::ACT_THS, threshold.0 & 0b0111_1111)?;
         self.write_register(Register::ACT_DUR, duration.0)
+    }
+
+    /// Reboot memory content
+    pub fn reboot_memory_content(&mut self) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        self.register_set_bits(Register::CTRL5, 0b1000_0000)
+    }
+
+    const FIFO_ENABLE_BIT: u8 = 0b0100_0000;
+
+    /// Configures FIFO and then enables it
+    pub fn enable_fifo(
+        &mut self,
+        mode: FifoMode,
+        threshold: u8,
+    ) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        debug_assert!(threshold <= 0b0001_1111);
+
+        let bits = (threshold & 0b0001_1111) | mode.to_bits();
+        self.write_register(Register::FIFO_CTRL, bits)?;
+        self.register_set_bits(Register::CTRL5, Self::FIFO_ENABLE_BIT)
+    }
+
+    /// Disable FIFO. This resets the FIFO state
+    pub fn disable_fifo(&mut self) -> Result<(), Error<CORE::BusError, CORE::PinError>> {
+        self.write_register(Register::FIFO_CTRL, 0x00)?;
+        self.register_clear_bits(Register::CTRL5, Self::FIFO_ENABLE_BIT)
+    }
+
+    /// Get the status of the FIFO
+    pub fn get_fifo_status(&mut self) -> Result<FifoStatus, Error<CORE::BusError, CORE::PinError>> {
+        let status = self.read_register(Register::FIFO_SRC)?;
+
+        Ok(FifoStatus::from_bits(status))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,7 @@ where
     }
 
     /// Clear the given bits in the given register.
-    fn register_clear_bits(
+    pub fn register_clear_bits(
         &mut self,
         reg: Register,
         bits: u8,
@@ -410,7 +410,7 @@ where
     }
 
     /// Set the given bits in the given register.
-    fn register_set_bits(
+    pub fn register_set_bits(
         &mut self,
         reg: Register,
         bits: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ impl<CORE> Lis3dh<CORE>
 where
     CORE: Lis3dhCore,
 {
-    /// Initalize the device given the configuration
+    /// Configure the device
     pub fn configure(
         &mut self,
         conf: Configuration,
@@ -400,7 +400,11 @@ where
         self.write_register(register, f(value))
     }
 
-    /// Clear the given bits in the given register.
+    /// Clear the given bits in the given register. For example:
+    ///
+    ///     lis3dh.register_clear_bits(0b0110)
+    ///
+    /// This call clears (sets to 0) the bits at index 1 and 2. Other bits of the register are not touched.
     pub fn register_clear_bits(
         &mut self,
         reg: Register,
@@ -409,7 +413,11 @@ where
         self.modify_register(reg, |v| v & !bits)
     }
 
-    /// Set the given bits in the given register.
+    /// Set the given bits in the given register. For example:
+    ///
+    ///     lis3dh.register_set_bits(0b0110)
+    ///
+    /// This call sets to 1 the bits at index 1 and 2. Other bits of the register are not touched.
     pub fn register_set_bits(
         &mut self,
         reg: Register,
@@ -528,7 +536,7 @@ where
 
     /// Set the minimum magnitude for the Interrupt event to be recognized.
     ///
-    /// Example: the event has have a magnitude of at least 1.1g to be recognized.
+    /// Example: the event has to have a magnitude of at least 1.1g to be recognized.
     ///
     ///     // let mut lis3dh = ...
     ///     let threshold = Threshold::g(Range::G2, 1.1);

--- a/src/register.rs
+++ b/src/register.rs
@@ -329,3 +329,24 @@ pub const ZYXDA: u8 = 0b0000_1000;
 pub const ZDA: u8 = 0b0000_0100;
 pub const YDA: u8 = 0b0000_0010;
 pub const XDA: u8 = 0b0000_0001;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn threshold_g_vs_mg() {
+        assert_eq!(
+            Threshold::g(Range::G2, 1.5),
+            Threshold::mg(Range::G2, 1500.0)
+        );
+    }
+
+    #[test]
+    fn duration_seconds_vs_miliseconds() {
+        assert_eq!(
+            Duration::seconds(DataRate::Hz_400, 1.5),
+            Duration::miliseconds(DataRate::Hz_400, 1500.0)
+        );
+    }
+}

--- a/src/register.rs
+++ b/src/register.rs
@@ -139,7 +139,7 @@ impl Default for Range {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct Threshold(pub(crate) u8);
 
 impl Threshold {
@@ -162,6 +162,8 @@ impl Threshold {
 
         Threshold(result as u8)
     }
+
+    pub const ZERO: Self = Threshold(0);
 }
 
 /// Output data rate.
@@ -213,7 +215,7 @@ impl DataRate {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
 pub struct Duration(pub(crate) u8);
 
 impl Duration {
@@ -234,6 +236,8 @@ impl Duration {
     pub fn miliseconds(output_data_rate: DataRate, miliseconds: f32) -> Self {
         Self::seconds(output_data_rate, miliseconds * 1000.0)
     }
+
+    pub const ZERO: Self = Duration(0);
 }
 
 /// Data status structure. Decoded from the `STATUS_REG` register.

--- a/src/register.rs
+++ b/src/register.rs
@@ -156,23 +156,25 @@ impl Threshold {
     pub fn mg(range: Range, mgs: f32) -> Self {
         let value = mgs / (range.as_mg() as f32);
 
-        // a crude `.ceil()`, which is not available in with no_std
-        let result = {
-            let truncated = value as u64;
-
-            let round_up = value - (truncated as f32) > 0.0;
-
-            if round_up {
-                truncated + 1
-            } else {
-                truncated
-            }
-        };
+        let result = crude_ceil(value);
 
         Threshold(result.try_into().unwrap())
     }
 
     pub const ZERO: Self = Threshold(0);
+}
+
+/// a crude `.ceil()`, the std one is not currently available when using no_std
+fn crude_ceil(value: f32) -> u64 {
+    let truncated = value as u64;
+
+    let round_up = value - (truncated as f32) > 0.0;
+
+    if round_up {
+        truncated + 1
+    } else {
+        truncated
+    }
 }
 
 /// Output data rate.


### PR DESCRIPTION
Turns out we needed some extra stuff

In practice we often needed access to raw registers, so I have exposed that functionality. If you are concerned with exposing implementation details in this way we can put it behind a feature flag.

Furthermore, we use the FIFO feature which stores measurements on the lis3dh itself and then lets you read them in batches to hopefully save on energy.