### PR TITLE
fix duration milisecond behaviour

### DIFF
--- a/src/register.rs
+++ b/src/register.rs
@@ -233,7 +233,7 @@ impl Duration {
     /// Convert a number of seconds into a duration. Internally a duration is represented
     /// as a multiple of `1 / ODR` where ODR (the output data rate) is of type [`DataRate`].
     #[inline(always)]
-    pub fn seconds(output_data_rate: DataRate, seconds: f32) -> Self {
+    pub const fn seconds(output_data_rate: DataRate, seconds: f32) -> Self {
         let duration = output_data_rate.sample_rate() * seconds;
 
         Self(duration as u8)
@@ -244,8 +244,8 @@ impl Duration {
     ///
     ///     assert_eq!(Duration::miliseconds(DataRate::Hz_400, 25.0), 10);
     #[inline(always)]
-    pub fn miliseconds(output_data_rate: DataRate, miliseconds: f32) -> Self {
-        Self::seconds(output_data_rate, miliseconds * 1000.0)
+    pub const fn miliseconds(output_data_rate: DataRate, miliseconds: f32) -> Self {
+        Self::seconds(output_data_rate, miliseconds / 1000.0)
     }
 
     pub const ZERO: Self = Duration(0);


### PR DESCRIPTION
milliseconds should be divided by 1000 to become seconds, it was setting incorrect duration to 255 (u8 max) with small values