### PR TITLE
high level api to configure High pass filter on interrupt

### DIFF
--- a/examples/motion_wakeup.rs
+++ b/examples/motion_wakeup.rs
@@ -1,0 +1,117 @@
+#![no_std]
+#![no_main]
+
+use circuit_playground_express as hal;
+extern crate panic_halt;
+
+use cortex_m_rt::entry;
+use cortex_m_semihosting::hprintln;
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::sercom::{I2CMaster1, PadPin};
+use hal::time::KiloHertz;
+
+use lis3dh::{
+    DataRate, Detect4D, Duration, HighPassFilterConfig, Interrupt1, InterruptConfig,
+    InterruptMode, IrqPin1Config, LatchInterruptRequest, Lis3dh, Range, SlaveAddr, Threshold,
+};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let gclk0 = clocks.gclk0();
+
+    let i2c = I2CMaster1::new(
+        &clocks.sercom1_core(&gclk0).unwrap(),
+        KiloHertz(400),
+        peripherals.SERCOM1,
+        &mut peripherals.PM,
+        pins.accel_sda.into_pad(&mut pins.port),
+        pins.accel_scl.into_pad(&mut pins.port),
+    );
+
+    let mut lis3dh = Lis3dh::new_i2c(i2c, SlaveAddr::Alternate).unwrap();
+
+    let data_rate = DataRate::Hz_200;
+    let wakeup_threshold = 500.0;
+    let threshold = Threshold::mg(Range::G2, wakeup_threshold);
+
+    // At 200Hz, each sample is 5ms. Duration of 0.020s = 4 samples
+    let duration = Duration::seconds(data_rate, 0.020);
+
+    // Set the output data rate
+    lis3dh.set_datarate(data_rate).unwrap();
+
+    // Set minimum acceleration threshold to trigger interrupt
+    lis3dh
+        .configure_irq_threshold(Interrupt1, threshold)
+        .unwrap();
+
+    // Set minimum duration threshold must be exceeded to trigger interrupt
+    lis3dh.configure_irq_duration(Interrupt1, duration).unwrap();
+
+    // Configure interrupt to trigger on high events (motion above threshold)
+    // OR any axis, latched until read, 4D detection (ignore Z-axis rotation)
+    lis3dh
+        .configure_irq_src_and_control(
+            Interrupt1,
+            InterruptMode::OrCombination,
+            InterruptConfig::high(),
+            LatchInterruptRequest::Enable,
+            Detect4D::Enable,
+        )
+        .unwrap();
+
+    // Route interrupt 1 signal to physical INT1 pin
+    lis3dh
+        .configure_interrupt_pin(IrqPin1Config {
+            ia1_en: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+    // Enable high-pass filter for interrupt path to remove DC component (gravity)
+    // This allows detection of motion/acceleration changes while ignoring gravity
+    // Data output remains unfiltered so you still get absolute acceleration values
+    lis3dh
+        .configure_high_pass_filter(HighPassFilterConfig {
+            enable_for_interrupt1: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+    // Clear any stale latched interrupt before use
+    let _ = lis3dh.get_irq_src(Interrupt1);
+
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    hprintln!("Motion wakeup configured. Waiting for movement...").ok();
+
+    loop {
+        // Check if interrupt was triggered
+        let irq_src = lis3dh.get_irq_src(Interrupt1).unwrap();
+
+        if irq_src.interrupt_active {
+            hprintln!("Motion detected!").ok();
+            hprintln!(
+                "  X: {}, Y: {}, Z: {}",
+                irq_src.x_axis_high,
+                irq_src.y_axis_high,
+                irq_src.z_axis_high
+            )
+            .ok();
+        }
+
+        delay.delay_ms(100u16);
+    }
+}

--- a/examples/motion_wakeup.rs
+++ b/examples/motion_wakeup.rs
@@ -14,8 +14,8 @@ use hal::sercom::{I2CMaster1, PadPin};
 use hal::time::KiloHertz;
 
 use lis3dh::{
-    DataRate, Detect4D, Duration, HighPassFilterConfig, Interrupt1, InterruptConfig,
-    InterruptMode, IrqPin1Config, LatchInterruptRequest, Lis3dh, Range, SlaveAddr, Threshold,
+    DataRate, Detect4D, Duration, HighPassFilterConfig, Interrupt1, InterruptConfig, InterruptMode,
+    IrqPin1Config, LatchInterruptRequest, Lis3dh, Range, SlaveAddr, Threshold,
 };
 
 #[entry]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,13 +77,13 @@ where
     ///
     ///     use nrf52840_hal::gpio::{Level, PushPull};
     ///     use lis3dh::Lis3dh;
-    ///     
+    ///
     ///     let peripherals = nrf52840_hal::pac::Peripherals::take().unwrap();
     ///     let pins = p0::Parts::new(peripherals.P0);
-    ///     
+    ///
     ///     let twim0_scl = pins.p0_31.into_floating_input().degrade();
     ///     let twim0_sda = pins.p0_30.into_floating_input().degrade();
-    ///     
+    ///
     ///     let i2c = nrf52840_hal::twim::Twim::new(
     ///         peripherals.TWIM0,
     ///         nrf52840_hal::twim::Pins {
@@ -92,7 +92,7 @@ where
     ///         },
     ///         nrf52840_hal::twim::Frequency::K400,
     ///     );
-    ///     
+    ///
     ///     let lis3dh = Lis3dh::new_i2c(i2c, lis3dh::SlaveAddr::Default).unwrap();
     pub fn new_i2c(
         i2c: I2C,
@@ -130,20 +130,20 @@ where
     ///     use nrf52840_hal::gpio::{p0::{Parts, P0_28}, *};
     ///     use nrf52840_hal::spim::Spim;
     ///     use lis3dh::Lis3dh;
-    ///     
+    ///
     ///     let peripherals = nrf52840_hal::pac::Peripherals::take().unwrap();
     ///     let port0 = Parts::new(peripherals.P0);
-    ///     
+    ///
     ///     // define the chip select pin
     ///     let cs: P0_28<Output<PushPull>> = port0.p0_28.into_push_pull_output(Level::High);
-    ///     
+    ///
     ///     // spi pins: clock, miso, mosi
     ///     let pins = nrf52840_hal::spim::Pins {
     ///         sck: port0.p0_31.into_push_pull_output(Level::Low).degrade(),
     ///         miso: Some(port0.p0_30.into_push_pull_output(Level::Low).degrade()),
     ///         mosi: Some(port0.p0_29.into_floating_input().degrade()),
     ///     };
-    ///     
+    ///
     ///     // set up the spi peripheral
     ///     let spi = Spim::new(
     ///         peripherals.SPIM2,
@@ -700,7 +700,7 @@ where
 
     /// Configure 'Sleep to wake' and 'Return to sleep' threshold and duration.
     ///
-    /// The LIS3DH can be programmed to automatically switch to low-power mode upon recognition of a determined event.  
+    /// The LIS3DH can be programmed to automatically switch to low-power mode upon recognition of a determined event.
     /// Once the event condition is over, the device returns back to the preset normal or highresolution mode.
     ///
     /// Example: enter low-power mode. When a measurement above 1.1g is registered, then wake up
@@ -710,12 +710,12 @@ where
     ///
     ///     let range = Range::default();
     ///     let data_rate = DataRate::Hz_400;
-    ///     
+    ///
     ///     let threshold = Threshold::g(range, 1.1);
     ///     let duration = Duration::miliseconds(data_rate, 25.0);
-    ///     
+    ///
     ///     lis3dh.configure_switch_to_low_power(threshold, duration)?;
-    ///     
+    ///
     ///     lis3dh.set_datarate(data_rate)?;
     #[doc(alias = "ACT_THS")]
     #[doc(alias = "ACT_DUR")]

--- a/src/register.rs
+++ b/src/register.rs
@@ -251,6 +251,55 @@ impl Duration {
     pub const ZERO: Self = Duration(0);
 }
 
+/// High-pass filter mode selection.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HighPassFilterMode {
+    /// Normal mode (reset by reading REFERENCE register)
+    Normal = 0b00,
+    /// Reference signal for filtering
+    Reference = 0b01,
+    /// Autoreset on interrupt event
+    AutoresetOnInterrupt = 0b10,
+}
+
+impl Default for HighPassFilterMode {
+    fn default() -> Self {
+        HighPassFilterMode::Normal
+    }
+}
+
+/// High-pass filter cutoff frequency.
+/// Actual cutoff frequency depends on ODR (output data rate).
+/// See LIS3DH datasheet Table 27 for frequency values.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum HighPassFilterCutoff {
+    /// Lowest cutoff frequency
+    Lowest = 0b00,
+    /// Low cutoff frequency
+    Low = 0b01,
+    /// Medium cutoff frequency
+    Medium = 0b10,
+    /// High cutoff frequency
+    High = 0b11,
+}
+
+impl Default for HighPassFilterCutoff {
+    fn default() -> Self {
+        HighPassFilterCutoff::Lowest
+    }
+}
+
+/// High-pass filter configuration.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct HighPassFilterConfig {
+    pub mode: HighPassFilterMode,
+    pub cutoff: HighPassFilterCutoff,
+    pub enable_for_interrupt1: bool,
+    pub enable_for_interrupt2: bool,
+    pub enable_for_click: bool,
+    pub enable_for_data: bool,
+}
+
 /// Click source structure. Decoded from the `CLICK_SRC` register.
 ///
 /// `CLICK_SRC` has the following bit fields:
@@ -429,6 +478,13 @@ pub const ZYXDA: u8 = 0b0000_1000;
 pub const ZDA: u8 = 0b0000_0100;
 pub const YDA: u8 = 0b0000_0010;
 pub const XDA: u8 = 0b0000_0001;
+
+// === CTRL_REG2 (21h) ===
+
+pub const FDS: u8 = 0b0000_1000;
+pub const HPCLICK: u8 = 0b0000_0100;
+pub const HPIS2: u8 = 0b0000_0010;
+pub const HPIS1: u8 = 0b0000_0001;
 
 // === CLICK_CFG (38h) ===
 


### PR DESCRIPTION
Users configuring motion detection interrupts need to enable the high-pass filter to remove the DC component (gravity) from interrupt detection while keeping raw acceleration data unfiltered. Previously, this required manual register manipulation:

```rust
// Old way - manual register manipulation
let mut reg2 = lis.read_register(Register::CTRL2).unwrap_or(0);
reg2 |= 0b0000_0001;  // Enable HPF for INT1
reg2 &= !0b0000_1000; // Keep HPF off data path
lis.write_register(Register::CTRL2, reg2).unwrap();
```

## Solution

This PR adds a clean, type-safe API:

```rust
// New way - type-safe API
lis.configure_high_pass_filter(HighPassFilterConfig {
    enable_for_interrupt1: true,
    ..Default::default()
})?;
```

## Changes

### New Types
- `HighPassFilterMode`: Normal, Reference, AutoresetOnInterrupt
- `HighPassFilterCutoff`: Lowest, Low, Medium, High (with datasheet reference)
- `HighPassFilterConfig`: Complete configuration structure

### New Methods
- `configure_high_pass_filter()`: Set HPF configuration
- `get_high_pass_filter_config()`: Read current HPF settings